### PR TITLE
Add support for name imports without adding the entire JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,27 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime-corejs2": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
+      "integrity": "sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -1030,10 +1051,12 @@
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.1.1.tgz",
+      "integrity": "sha512-pSJTQCBDZxv8siK5p/M42ZdhThhTtx3JU/OKli0yQSKebfM9q92op6zF7krYrWVKRtsE/RwTDiZLliMV3ECkXQ==",
+      "requires": {
+        "xregexp": "^4.2.4"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -4378,6 +4401,14 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "xregexp": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
+      "integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.2.0"
+      }
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -4402,6 +4433,14 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1 || ^4.0.0",
         "yargs-parser": "^11.1.1"
+      },
+      "dependencies": {
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        }
       }
     },
     "yargs-parser": {
@@ -4412,6 +4451,14 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        }
       }
     },
     "yargs-unparser": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/yggie/babel-plugin-inline-json-import#readme",
   "dependencies": {
-    "decache": "^4.5.1"
+    "decache": "^4.5.1",
+    "decamelize": "^3.1.1"
   }
 }

--- a/test/fixtures/named-example.json
+++ b/test/fixtures/named-example.json
@@ -1,0 +1,6 @@
+{
+  "used": true,
+  "unused": false,
+  "otherUsed": true,
+  "kebab-example": true
+}

--- a/test/inline-json-imports.spec.js
+++ b/test/inline-json-imports.spec.js
@@ -37,21 +37,6 @@ describe('babel-plugin-inline-json-imports', () => {
     `))
   })
 
-  it('supports destructuring of the JSON imports', () => {
-    const t = configureTransform()
-    const result = t(`
-      import {example} from '../test/fixtures/example.json'
-
-      console.log(example)
-    `)
-
-    expect(normalize(result.code)).to.equal(normalize(`
-      const { example: example } = { example: true }
-
-      console.log(example)
-    `))
-  })
-
   it('does not inline other kinds of imports', () => {
     const t = configureTransform()
     const result = t(`
@@ -158,6 +143,83 @@ describe('babel-plugin-inline-json-imports', () => {
 
       const file = require('../src/index.js')
       const example = require('./example')
+    `))
+  })
+
+  it('supports named import from a JSON', () => {
+    const t = configureTransform()
+    const result = t(`
+      import { used } from '../test/fixtures/named-example.json'
+
+      console.log(used)
+    `)
+
+    expect(normalize(result.code)).to.equal(normalize(`
+      const used = true
+
+      console.log(used)
+    `))
+  })
+
+  it('supports named import with a alias name from a JSON', () => {
+    const t = configureTransform()
+    const result = t(`
+      import { used as otherName } from '../test/fixtures/named-example.json'
+
+      console.log(otherName)
+    `)
+
+    expect(normalize(result.code)).to.equal(normalize(`
+      const otherName = true
+
+      console.log(otherName)
+    `))
+  })
+
+  it('supports two named import from a JSON', () => {
+    const t = configureTransform()
+    const result = t(`
+      import { used, otherUsed } from '../test/fixtures/named-example.json'
+
+      console.log(used, otherName)
+    `)
+
+    expect(normalize(result.code)).to.equal(normalize(`
+      const used = true
+      const otherUsed = true
+
+      console.log(used, otherName)
+    `))
+  })
+
+  it('supports two named import with a alias name from a JSON', () => {
+    const t = configureTransform()
+    const result = t(`
+      import { used as one, otherUsed as two } from '../test/fixtures/named-example.json'
+
+      console.log(one, two)
+    `)
+
+    expect(normalize(result.code)).to.equal(normalize(`
+      const one = true
+      const two = true
+
+      console.log(one, two)
+    `))
+  })
+
+  it('supports kebab named import from a JSON', () => {
+    const t = configureTransform()
+    const result = t(`
+      import { kebabExample } from '../test/fixtures/named-example.json'
+
+      console.log(kebabExample)
+    `)
+
+    expect(normalize(result.code)).to.equal(normalize(`
+      const kebabExample = true
+
+      console.log(kebabExample)
     `))
   })
 


### PR DESCRIPTION
Currently this plugin supports named imports using object destructuring but imports the complete JSON content even if only one property is being used.

This update change to `const` declarations and only includes the values that are being imported. Also support kebab conversion to support `foo-bar` type of properties. 